### PR TITLE
Updated opneapi specification

### DIFF
--- a/.github/workflows/sdk_generator.yml
+++ b/.github/workflows/sdk_generator.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install OpenAPI Generator
         run: |
-          npm install -g @openapitools/openapi-generator-cli@latest
+          npm install -g @openapitools/openapi-generator-cli@7.11.0
 
       - name: Generate Python SDK
         run: |


### PR DESCRIPTION
This PR updates the OpenAPI Generator version used in our GitHub Actions workflow to ensure compatibility with urllib3 versions 2.1.0 and above. Specifically:

Updated OpenAPI Generator Version: Changed from latest to 7.11.0 in the workflow.

Pinned urllib3 Version: Added a version constraint in requirements.txt to restrict urllib3 to versions below 2.0.0.

